### PR TITLE
Create standalone evictor pages, date last updated, and backlinks to AEMP site

### DIFF
--- a/plugins/data-fetch/fetchEvictorData.ts
+++ b/plugins/data-fetch/fetchEvictorData.ts
@@ -26,7 +26,7 @@ export default async function fetchEvictorData() {
         const { ebEntry, name, pullQuote, citywideListDescription } =
           item.fields
 
-        const evictorNameFormatted = formatLink(name)
+        const evictorNameFormatted = formatLink(name) // created formatted version of name
 
         if (!ebEntry?.length) {
           console.warn(
@@ -133,7 +133,7 @@ export default async function fetchEvictorData() {
           ...item.fields,
           id: item.sys.id,
           ebData,
-          nameFormatted: evictorNameFormatted,
+          nameFormatted: evictorNameFormatted, // add in formatted name as queryable field
           totalEvictions,
           activeSince,
           totalUnits,

--- a/plugins/data-fetch/fetchEvictorData.ts
+++ b/plugins/data-fetch/fetchEvictorData.ts
@@ -2,6 +2,7 @@ import "dotenv/config"
 import { createClient } from "contentful"
 import type { EntryCollection } from "contentful"
 import getEBEntry from "./getEBEntry"
+import { formatLink } from "../../src/utils/string"
 
 export default async function fetchEvictorData() {
   const client = createClient({
@@ -24,6 +25,8 @@ export default async function fetchEvictorData() {
         // this is how the contentful cms presents it too
         const { ebEntry, name, pullQuote, citywideListDescription } =
           item.fields
+
+        const evictorNameFormatted = formatLink(name)
 
         if (!ebEntry?.length) {
           console.warn(
@@ -93,9 +96,8 @@ export default async function fetchEvictorData() {
           await ebData.reduce(
             async (shells: Promise<string[]>, business) => {
               const networkId = business.networkDetails[0].network_id
-              const networkUrl = `${
-                process.env.EB_DOMAIN || "https://evictorbook.com"
-              }/api/network/${networkId}/nodes`
+              const networkUrl = `${process.env.EB_DOMAIN || "https://evictorbook.com"
+                }/api/network/${networkId}/nodes`
               const nodes = await fetch(networkUrl).then((res) =>
                 res.json()
               )
@@ -131,6 +133,7 @@ export default async function fetchEvictorData() {
           ...item.fields,
           id: item.sys.id,
           ebData,
+          nameFormatted: evictorNameFormatted,
           totalEvictions,
           activeSince,
           totalUnits,

--- a/src/components/Evictor.tsx
+++ b/src/components/Evictor.tsx
@@ -1,24 +1,27 @@
 import React from 'react'
 import renderContent from '../utils/contentful-render'
-import {OutboundLink} from './OutboundLink'
-import type {EvictorProps} from '../queries/list'
-import {getImage} from 'gatsby-plugin-image'
+import { OutboundLink } from './OutboundLink'
+import type { EvictorProps } from '../queries/list'
+import { getImage } from 'gatsby-plugin-image'
 import {
   FormatBusinessAddress,
   titleCase,
 } from '../utils/string'
 import EvictorImage from './EvictorImage'
 import pin from '../images/pin.svg'
-import {formatLink} from '../utils/string'
+import { formatLink } from '../utils/string'
 
 import '../styles/list.scss'
 
 const EvictorProfile: React.FC<{
   content: EvictorProps
   city: string
-}> = ({content, city}) => {
-  const {networkDetails, details} = content.ebData[0]
+}> = ({ content, city }) => {
+  const { networkDetails, details } = content.ebData[0]
   const activeSince = content.activeSince
+
+  const formatter = new Intl.DateTimeFormat('en-US', { dateStyle: 'medium' })
+  const dateLastUpdated = formatter.format(new Date(content.lastUpdated))
 
   return (
     <section
@@ -68,6 +71,14 @@ const EvictorProfile: React.FC<{
                   name={content.photoCaption}
                   hideEyebrow
                 />
+                {content.aempUrl && (
+                  <OutboundLink
+                    href={content.aempUrl}
+                    className="btn btn-primary"
+                  >
+                    See AEMP's original profile on this landlord
+                  </OutboundLink>
+                )}
                 {content.banks?.length ? (
                   <p>
                     <span className="stat-name">Funded By</span>
@@ -120,6 +131,10 @@ const EvictorProfile: React.FC<{
                     's portfolio
                   </OutboundLink>
                 ))}
+                {content.lastUpdated && (<span className="date_updated">
+                  Profile last updated on {dateLastUpdated}
+                </span>
+                )}
               </>
             )}
           </div>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -49,7 +49,7 @@ const Layout = ({
         <meta property="og:title" content={title} />
         <meta property="og:description" content={description} />
         <meta property="og:url" content={url} />
-        <meta property="og:image" content={shareImage} />
+        <meta property="og:image" content={shareImageURL} />
         <meta property="og:type" content="website" />
 
         <meta name="twitter:card" content="summary_large_image" />
@@ -58,7 +58,7 @@ const Layout = ({
         <meta name="twitter:title" content={title} />
         <meta name="twitter:description" content={description} />
         <meta name="twitter:url" content={url} />
-        <meta name="twitter:image" content={shareImage} />
+        <meta name="twitter:image" content={shareImageURL} />
         <meta
           name="twitter:image:alt"
           content="The Worst Evictors of San Francisco and Oakland"

--- a/src/pages/evictor/{Evictor.nameFormatted}.tsx
+++ b/src/pages/evictor/{Evictor.nameFormatted}.tsx
@@ -5,9 +5,11 @@ import type { EvictorProps } from '../../queries/list'
 import useListQuery from '../../queries/list'
 import Header from '../../components/Header'
 import Footer from '../../components/Footer'
+import { renderToString } from 'react-dom/server';
 
 import '../../styles/list.scss'
 import { sortEvictors } from '../../utils/misc'
+import renderContent from '../../utils/contentful-render'
 
 const SingleEvictorPage = (props) => {
   // pull the evictor ID populated through Gatsby's "collection route" setup for dynamic pages
@@ -31,7 +33,9 @@ const SingleEvictorPage = (props) => {
   return (
     <Layout
       customTitle={`${evictorToDisplay.name} | The Worst Evictors of San Francisco and Oakland`}
-      customDescription={data.contentfulCitywideListPage.title}
+      customDescription={evictorToDisplay.citywideListDescription &&
+        renderToString(renderContent(evictorToDisplay.citywideListDescription))}
+      customImage={evictorToDisplay.localFile.childImageSharp.gatsbyImageData.images.fallback.src}
       className="page"
       hideFooter
     >

--- a/src/pages/evictor/{Evictor.nameFormatted}.tsx
+++ b/src/pages/evictor/{Evictor.nameFormatted}.tsx
@@ -10,9 +10,10 @@ import '../../styles/list.scss'
 import { sortEvictors } from '../../utils/misc'
 
 const SingleEvictorPage = (props) => {
-  // pull the evictor name populated through Gatsby's "collection route" setup for dynamic pages
+  // pull the evictor ID populated through Gatsby's "collection route" setup for dynamic pages
   // See more here: https://www.gatsbyjs.com/docs/reference/routing/file-system-route-api
-  const evictorName = props.params.nameFormatted
+  const evictorId = props.pageContext.id
+
   const data = useListQuery() // pull the full list of evictors
   const evictors = sortEvictors(
     data.allEvictor.nodes
@@ -23,12 +24,13 @@ const SingleEvictorPage = (props) => {
   *
   * TODO - if this becomes a performance issue, can restructure around a dynamic query
   */
-  const evictor_to_display = evictors.filter((evictor) => evictor.nameFormatted == evictorName)[0]
-  const evictor_city = evictor_to_display.city == "sf" ? 'San Francisco' : 'Oakland'
+
+  const evictorToDisplay = evictors.filter((evictor) => evictor.id == evictorId)[0]
+  const evictorCity = evictorToDisplay.city == "sf" ? 'San Francisco' : 'Oakland'
 
   return (
     <Layout
-      customTitle="The Worst Evictors of San Francisco and Oakland"
+      customTitle={`${evictorToDisplay.name} | The Worst Evictors of San Francisco and Oakland`}
       customDescription={data.contentfulCitywideListPage.title}
       className="page"
       hideFooter
@@ -37,7 +39,7 @@ const SingleEvictorPage = (props) => {
         <Header isDescription={false} />
       </div>
       <div className="scroll-container">
-        <EvictorProfile content={evictor_to_display} city={evictor_city} />
+        <EvictorProfile content={evictorToDisplay} city={evictorCity} />
         <Footer />
       </div>
     </Layout>

--- a/src/pages/evictor/{Evictor.nameFormatted}.tsx
+++ b/src/pages/evictor/{Evictor.nameFormatted}.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import Layout from '../../components/Layout'
+import EvictorProfile from '../../components/Evictor'
+import type { EvictorProps } from '../../queries/list'
+import useIndexQuery from '../../queries/list'
+import Header from '../../components/Header'
+import Footer from '../../components/Footer'
+
+import '../../styles/list.scss'
+import { sortEvictors } from '../../utils/misc'
+
+const SingleEvictorPage = (props) => {
+  const evictorName = props.params.nameFormatted
+  const data = useIndexQuery()
+  console.log(`Evictor name: ${evictorName}`)
+  const evictors = sortEvictors(
+    data.allEvictor.nodes
+  ) as EvictorProps[]
+
+  /* Because static GraphQL queries don't allow for variables / dynamic searches, easiest to 
+  * pull the full list of evictors and then filter here.
+  *
+  * TODO - if this becomes a performance issue, can restructure around a dynamic query
+  */
+  const evictor_to_display = evictors.filter((evictor) => evictor.nameFormatted == evictorName)[0]
+
+  return (
+    <Layout
+      customTitle="The Worst Evictors of San Francisco and Oakland"
+      customDescription={data.contentfulCitywideListPage.title}
+      className="page"
+      hideFooter
+    >
+      <div className="header-container">
+        <Header isDescription={false} />
+      </div>
+      <div className="scroll-container">
+        <EvictorProfile content={evictor_to_display} city={"san-francisco"} />
+        <Footer />
+      </div>
+    </Layout>
+  )
+}
+
+export default SingleEvictorPage

--- a/src/pages/evictor/{Evictor.nameFormatted}.tsx
+++ b/src/pages/evictor/{Evictor.nameFormatted}.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import Layout from '../../components/Layout'
 import EvictorProfile from '../../components/Evictor'
 import type { EvictorProps } from '../../queries/list'
-import useIndexQuery from '../../queries/list'
+import useListQuery from '../../queries/list'
 import Header from '../../components/Header'
 import Footer from '../../components/Footer'
 
@@ -10,19 +10,21 @@ import '../../styles/list.scss'
 import { sortEvictors } from '../../utils/misc'
 
 const SingleEvictorPage = (props) => {
+  // pull the evictor name populated through Gatsby's "collection route" setup for dynamic pages
+  // See more here: https://www.gatsbyjs.com/docs/reference/routing/file-system-route-api
   const evictorName = props.params.nameFormatted
-  const data = useIndexQuery()
-  console.log(`Evictor name: ${evictorName}`)
+  const data = useListQuery() // pull the full list of evictors
   const evictors = sortEvictors(
     data.allEvictor.nodes
   ) as EvictorProps[]
 
   /* Because static GraphQL queries don't allow for variables / dynamic searches, easiest to 
-  * pull the full list of evictors and then filter here.
+  * pull the full list of evictors and then filter here to the evictor for this page.
   *
   * TODO - if this becomes a performance issue, can restructure around a dynamic query
   */
   const evictor_to_display = evictors.filter((evictor) => evictor.nameFormatted == evictorName)[0]
+  const evictor_city = evictor_to_display.city == "sf" ? 'San Francisco' : 'Oakland'
 
   return (
     <Layout
@@ -35,7 +37,7 @@ const SingleEvictorPage = (props) => {
         <Header isDescription={false} />
       </div>
       <div className="scroll-container">
-        <EvictorProfile content={evictor_to_display} city={"san-francisco"} />
+        <EvictorProfile content={evictor_to_display} city={evictor_city} />
         <Footer />
       </div>
     </Layout>

--- a/src/queries/list.ts
+++ b/src/queries/list.ts
@@ -9,6 +9,7 @@ export default function useListQuery() {
       }
       allEvictor {
         nodes {
+          id
           name
           nameFormatted
           city
@@ -65,6 +66,7 @@ export default function useListQuery() {
 
 /** might as well define some proptypes */
 export type EvictorProps = {
+  id: number
   name: string
   nameFormatted: string
   corporation: string

--- a/src/queries/list.ts
+++ b/src/queries/list.ts
@@ -1,7 +1,7 @@
 import { useStaticQuery, graphql } from 'gatsby'
 import { ImageDataLike } from 'gatsby-plugin-image'
 
-export default function useIndexQuery() {
+export default function useListQuery() {
   const data = useStaticQuery(graphql`
     query {
       contentfulCitywideListPage {
@@ -17,6 +17,8 @@ export default function useIndexQuery() {
           photoCaption
           shellCompanies
           tags
+          lastUpdated
+          aempUrl
           evictions {
             type
             evict_date
@@ -68,6 +70,8 @@ export type EvictorProps = {
   corporation: string
   city: string
   tags?: string[]
+  lastUpdated?: Date
+  aempUrl: string
   evictions: {
     type: string
     evict_date: string

--- a/src/queries/list.ts
+++ b/src/queries/list.ts
@@ -70,8 +70,8 @@ export type EvictorProps = {
   corporation: string
   city: string
   tags?: string[]
-  lastUpdated?: Date
-  aempUrl: string
+  lastUpdated?: string
+  aempUrl?: string
   evictions: {
     type: string
     evict_date: string

--- a/src/queries/list.ts
+++ b/src/queries/list.ts
@@ -1,5 +1,5 @@
-import {useStaticQuery, graphql} from 'gatsby'
-import {ImageDataLike} from 'gatsby-plugin-image'
+import { useStaticQuery, graphql } from 'gatsby'
+import { ImageDataLike } from 'gatsby-plugin-image'
 
 export default function useIndexQuery() {
   const data = useStaticQuery(graphql`
@@ -10,6 +10,7 @@ export default function useIndexQuery() {
       allEvictor {
         nodes {
           name
+          nameFormatted
           city
           nonprofitOrLowIncome
           corporation
@@ -63,6 +64,7 @@ export default function useIndexQuery() {
 /** might as well define some proptypes */
 export type EvictorProps = {
   name: string
+  nameFormatted: string
   corporation: string
   city: string
   tags?: string[]

--- a/src/styles/list.scss
+++ b/src/styles/list.scss
@@ -14,6 +14,7 @@
   display: grid;
   grid-template-rows: 1fr auto;
   max-height: 100vh;
+
   @media (min-width: 700px) {
     .scroll-container {
       overflow-y: scroll;
@@ -28,28 +29,35 @@
   border-bottom: solid 1px white;
   z-index: 1;
   width: 100%;
+
   h1 {
     font-size: 1.5rem !important;
     margin: 0 !important;
     margin-right: 0.5rem !important;
   }
+
   .header {
     width: 100%;
     padding: 0.5rem;
+
     .title-container {
       margin: 0 !important;
     }
+
     .title {
       place-items: center;
       margin: 0 !important;
+
       h1 {
         text-align: center;
       }
+
       img {
         height: 1.5rem;
       }
     }
   }
+
   .title-links {
     width: 100%;
     display: flex;
@@ -57,6 +65,7 @@
     justify-content: space-around;
     flex-wrap: wrap;
   }
+
   .links {
     place-items: center;
     place-content: center;
@@ -74,30 +83,43 @@
   and .link-target has position: absolute;
    */
   position: relative;
+
   .spacer {
     height: 10rem;
   }
+
   .city-name {
     display: flex;
     flex-direction: row;
     align-items: center;
     gap: 1rem;
+
     img {
       height: 1.5rem;
     }
+
     span {
       font-size: 1.5rem;
       margin: 0;
     }
+
     margin: 1rem 0;
   }
+
   .tags {
     margin: 1rem 0;
+
     .tag {
       font-style: italic;
       font-size: 1.5rem;
     }
   }
+}
+
+.date_updated {
+  margin: 2rem 0;
+  font-style: italic;
+  font-size: 1rem;
 }
 
 .col-container {
@@ -106,6 +128,7 @@
   flex-direction: row;
   flex-wrap: wrap;
   justify-content: space-around;
+
   .left,
   .right {
     flex: 1 1 50ch;
@@ -116,6 +139,7 @@
     flex-direction: column;
     place-items: center;
     margin: 0 1.5rem;
+
     .left-width-constrainer,
     .right-width-constrainer {
       width: 100%;
@@ -139,8 +163,8 @@
     font-weight: bold;
     text-transform: uppercase;
   }
+
   li {
     margin-left: 1rem;
   }
 }
-


### PR DESCRIPTION
Adds a few changes:
- Adds a new page for single evictors, under the URL `https://worstevictorsbayarea.org/evictor/{evictor_name}` such as `https://worstevictorsbayarea.org/evictor/robert-imhoff`. Uses the "formatted" version of the evictor name, which is lowercased and dash-separated. These standalone pages are not linked anywhere on the site.
- Adds a field on the evictor profiles for the date the profile was last updated (corresponding to a new `lastUpdated` field in the `evictor` Contentful model)
- Adds a button on the evictor profile for the backlink to the historical AEMP page (corresponding to a new `aempUrl` field in the `evictor` Contentful model)
- Also made some automatic formatting changes, but can revert those as needed

So far, I've only populated these new fields for Robert Imhoff. I also put these fields pretty arbitrarily in the left sidebar, which is now getting pretty busy, and probably should be moved elsewhere.